### PR TITLE
Update distroless.md

### DIFF
--- a/linux/container/image/distroless.md
+++ b/linux/container/image/distroless.md
@@ -41,3 +41,4 @@ Now we know why distroless is better in terms of security, but requires more eff
 
 [^1]: You can execute commands from your host OS inside another namespace via ```nsenter```, like this: ```nsenter -t $(docker inspect -f '{{.State.Pid}}' adguard-app-1) -n netstat -tulpn```. This means you can execute binaries which are not present in the distroless image from your host OS as if they were in the image, pretty neat
 [^2]: If you get the process ID of the container image you can view the file system under ```ls -lah /proc/$(docker inspect -f '{{.State.Pid}}' adguard-app-1)/root/*```
+_Note:_ The above commands won't directly work on MacOS (which runs `docker` and `podman` inside a VM), you must first enter a shell within that VM. `docker` doesn't offer a VM's shell, but `podman` does, open it with `podman machine ssh`.


### PR DESCRIPTION
Tried running the helper commands you provided on MacOS (while testing the `caddy` image) without success, turns out the VM's shell is where you should run those.

I don't have a workaround for Docker which isn't installed on my Mac, web searches weren't helpful enough to be more precise.

<img width="1122" height="761" alt="image" src="https://github.com/user-attachments/assets/3fbf5c92-a57e-4473-8424-e551f613423d" />
Seems like `nsenter` needs to be run as root on the VM
<img width="972" height="147" alt="image" src="https://github.com/user-attachments/assets/8ac1454e-1849-46a1-ba57-3c1b09edbf37" />
